### PR TITLE
fix: apply chapter actions before evaluating preview choices

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -948,6 +948,7 @@ class ChapterEditor(tk.Tk):
                 win.destroy()
                 return
             current = ch
+            apply_actions(ch)
             text.config(state="normal")
             text.delete("1.0", tk.END)
             for p in ch.paragraphs:
@@ -972,8 +973,6 @@ class ChapterEditor(tk.Tk):
                 ttk.Button(btn_frame, text="닫기", command=win.destroy).pack(pady=2)
 
         def choose(choice: Choice):
-            if current:
-                apply_actions(current)
             show(choice.target_id)
 
         start = self.story.start_id or next(iter(self.story.chapters.keys()), None)


### PR DESCRIPTION
## Summary
- apply chapter actions when a chapter is shown so preview evaluates updated state
- simplify preview choice handler

## Testing
- `python -m py_compile editor.py main.py`
- `python - <<'PY'
import editor
print('has_run_preview', hasattr(editor.ChapterEditor, '_run_preview'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b54b412014832b9fbc2837726430cb