### PR TITLE
fix: short-circuit boolean ops in evaluator

### DIFF
--- a/main.py
+++ b/main.py
@@ -625,11 +625,16 @@ class BranchingNovelApp(tk.Tk):
 
     def _eval_ast(self, node: ast.AST) -> Any:
         if isinstance(node, ast.BoolOp):
-            values = [self._eval_ast(v) for v in node.values]
             if isinstance(node.op, ast.And):
-                return all(values)
+                for v in node.values:
+                    if not self._eval_ast(v):
+                        return False
+                return True
             elif isinstance(node.op, ast.Or):
-                return any(values)
+                for v in node.values:
+                    if self._eval_ast(v):
+                        return True
+                return False
             else:
                 raise ValueError("Unsupported boolean operator")
         elif isinstance(node, ast.UnaryOp):


### PR DESCRIPTION
## Summary
- add short-circuit logic for boolean operations in custom AST evaluator

## Testing
- `python -m py_compile main.py editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b54b67a7e4832bbcb919129490a9a4