### PR TITLE
Handle meta lines safely in parser

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,6 +133,7 @@ class StoryParser:
     """
 
     def parse(self, text: str) -> Story:
+        text = text.lstrip("\ufeff")
         lines = text.splitlines()
         story = Story()
         current_chapter: Optional[Chapter] = None
@@ -160,6 +161,9 @@ class StoryParser:
             line = raw.rstrip("\n")
             stripped = line.strip()
             i += 1
+
+            if stripped.startswith("@"):
+                continue
 
             # 챕터 시작
             if stripped.startswith("#"):


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM before parsing story text
- Ignore lines beginning with `@` during the second parsing pass to avoid treating metadata as narrative

## Testing
- `python -m py_compile main.py editor.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b551809f74832ba02b0ddb1145a7b0