### PR TITLE
Handle @-metadata and BOM in story parser

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -147,7 +147,8 @@ class ParseError(Exception):
 
 class StoryParser:
     def parse(self, text: str) -> Story:
-        lines = text.splitlines()
+        text = text.lstrip("\ufeff")
+        lines = [ln.lstrip("\ufeff") for ln in text.splitlines()]
         story = Story()
         current: Optional[Chapter] = None
         buffer: List[str] = []
@@ -168,6 +169,9 @@ class StoryParser:
             line = raw.rstrip("\n")
             s = line.strip()
             i += 1
+
+            if s.startswith("@"):
+                continue
 
             if s.startswith("#"):
                 if current is not None and buffer:

--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ class StoryParser:
 
     def parse(self, text: str) -> Story:
         text = text.lstrip("\ufeff")
-        lines = text.splitlines()
+        lines = [ln.lstrip("\ufeff") for ln in text.splitlines()]
         story = Story()
         current_chapter: Optional[Chapter] = None
         paragraph_buffer: List[str] = []


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM and per-line BOM before parsing
- Ignore `@` metadata lines on second pass to prevent chapter errors

## Testing
- `python -m py_compile editor.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b644261cbc832b92839531303d3234