### PR TITLE
Fix preview crash by adding chapter lookup to editor story

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -71,6 +71,9 @@ class Story:
     chapters: Dict[str, Chapter] = field(default_factory=dict)
     variables: Dict[str, Union[int, float, bool]] = field(default_factory=dict)
 
+    def get_chapter(self, cid: str) -> Optional[Chapter]:
+        return self.chapters.get(cid)
+
     def chapter_ids(self) -> List[str]:
         return list(self.chapters.keys())
 


### PR DESCRIPTION
## Summary
- Add `get_chapter` method to `editor.py`'s `Story` class so runtime preview works

## Testing
- `python -m py_compile main.py editor.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b649fd7374832bb5238267fb86e9f0