### PR TITLE
Fix NameError for init_id in chapter editor startup

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -710,7 +710,8 @@ class ChapterEditor(tk.Tk):
         self._build_menu()
         self._build_ui()
         self._refresh_chapter_list()
-        self._load_chapter_to_form(init_id)
+        # initialize editor with the first chapter
+        self._load_chapter_to_form(ch_id)
         self._refresh_meta_panel()
         self._update_preview()
 


### PR DESCRIPTION
## Summary
- Replace undefined `init_id` with `ch_id` when loading the initial chapter in `ChapterEditor`
- Add clarifying comment for initial chapter loading

## Testing
- `python -m py_compile editor.py main.py`
- `python editor.py` *(fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)*

------
https://chatgpt.com/codex/tasks/task_e_68b65042c854832ba2a8d998cf65e317