### PR TITLE
Skip metadata lines during parsing loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,14 @@ class StoryParser:
                 story.chapters[current_chapter.chapter_id] = current_chapter
                 continue
 
+            # 기타 메타데이터는 1차 루프에서 처리했으므로 건너뛴다
+            if (
+                stripped.startswith("@title:")
+                or stripped.startswith("@start:")
+                or stripped.startswith("@ending:")
+            ):
+                continue
+
             # 분기 시작
             if stripped.startswith("#"):
                 if current_chapter is None:


### PR DESCRIPTION
## Summary
- Avoid treating `@title`, `@start`, and `@ending` lines as narrative text in the second parsing pass
- Prevent false "narrative text outside of a branch" errors

## Testing
- `python -m py_compile main.py editor.py`
- `python - <<'PY'
from main import StoryParser
story_text = """@title: Sample
@start: b1
@ending: The End

@chapter ch1: Chapter 1
# b1: Start
Hello
* Next -> b2

# b2: End
Goodbye
"""
parser = StoryParser()
story = parser.parse(story_text)
print(story.title, story.start_id, story.ending_text)
print(list(story.branches.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b6586b6928832b9a57ccd7bb9aef18