### PR TITLE
Handle metadata lines and fix search scope

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -185,6 +185,9 @@ class StoryParser:
             stripped = line.strip()
             i += 1
 
+            if stripped.startswith(("@title:", "@start:", "@ending:")):
+                continue
+
             if stripped.startswith("@chapter"):
                 current_branch = None
                 current_chapter = self._parse_chapter_decl(stripped)
@@ -1418,7 +1421,7 @@ class ChapterEditor(tk.Tk):
     def _build_find_results(self, query: str, scope: str):
         self._apply_body_to_model()
         results: List[Tuple[str, int]] = []
-        if scope == "chapter" and self.current_branch_id:
+        if scope == "branch" and self.current_branch_id:
             br = self.story.branches[self.current_branch_id]
             text = "\n\n".join(br.paragraphs)
             idx = text.find(query)


### PR DESCRIPTION
## Summary
- Ignore @title/@start/@ending lines in parser's main loop
- Check 'branch' scope correctly in find dialog

## Testing
- `python -m py_compile editor.py branching_novel.py`
- `python - <<'PY'
from editor import StoryParser
sample = """@title: My Story
@start: b1
@ending: The End
@chapter ch1
# b1
Hello
"""
parser = StoryParser()
st = parser.parse(sample)
print('Parsed title:', st.title, 'start:', st.start_id, 'ending:', st.ending_text)
print('Chapters:', list(st.chapters.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b65f266548832ba4859a7bcbd185ba