### PR TITLE
Associate bnov files with desktop apps

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Branching Novel GUI</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.branchingnovel</string>
+  <key>CFBundleExecutable</key>
+  <string>BranchingNovelGUI</string>
+  <key>CFBundleIconFile</key>
+  <string>appicon.icns</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>bnov</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>Branching Novel Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>CFBundleTypeIconFile</key>
+      <string>appicon.icns</string>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/installer.iss
+++ b/installer.iss
@@ -47,6 +47,13 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExe}"; Tasks: deskto
 [Run]
 Filename: "{app}\{#MyAppExe}"; Description: "{#MyAppName} 실행"; Flags: nowait postinstall skipifsilent
 
+[Registry]
+; .bnov 확장자를 Branching Novel GUI에 연결
+Root: HKCR; Subkey: ".bnov"; ValueType: string; ValueName: ""; ValueData: "BranchingNovelFile"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "BranchingNovelFile"; ValueType: string; ValueName: ""; ValueData: "Branching Novel Script"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "BranchingNovelFile\DefaultIcon"; ValueType: string; ValueData: "{app}\BranchingNovelGUI.exe,0"
+Root: HKCR; Subkey: "BranchingNovelFile\shell\open\command"; ValueType: string; ValueData: """{app}\BranchingNovelGUI.exe"" ""%1"""
+
 [Code]
 function IsPSAvailable(): Boolean;
 var ResultCode: Integer;


### PR DESCRIPTION
## Summary
- associate `.bnov` files with the Branching Novel GUI in Windows installer
- provide macOS Info.plist registering `.bnov` scripts

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py && echo py_compile_success`


------
https://chatgpt.com/codex/tasks/task_e_68b6ba766118832b81f5ef53550cdc23