### PR TITLE
Refine Windows build and installer workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,11 @@ jobs:
         run: |
           $iconArgs = @()
           if (Test-Path 'assets/icons/app.ico') { $iconArgs += @('--icon','assets/icons/app.ico') }
-          pyinstaller --noconfirm --windowed -n $env:EDITOR_APPNAME @iconArgs $env:EDITOR_ENTRY
+          $ver='${{ steps.rtag.outputs.version }}'
+          $fv=($ver.Split('.') + '0' + '0' + '0')[0..3] -join ','
+          ((Get-Content 'version-file-template.txt') -replace 'APP_NAME', $env:EDITOR_APPNAME -replace 'APP_VERSION', $ver -replace 'FILE_VERSION_COMMAS', $fv) |
+            Set-Content 'verinfo-editor.txt' -Encoding UTF8
+          pyinstaller --noconfirm --windowed --onedir --noupx --clean --version-file verinfo-editor.txt -n $env:EDITOR_APPNAME @iconArgs $env:EDITOR_ENTRY
           if (!(Test-Path "dist/$env:EDITOR_APPNAME")) { Write-Error "Editor dist missing"; exit 1 }
 
       - name: Build Viewer (folder mode)
@@ -85,7 +89,11 @@ jobs:
         run: |
           $iconArgs = @()
           if (Test-Path 'assets/icons/app.ico') { $iconArgs += @('--icon','assets/icons/app.ico') }
-          pyinstaller --noconfirm --windowed -n $env:VIEWER_APPNAME @iconArgs $env:VIEWER_ENTRY
+          $ver='${{ steps.rtag.outputs.version }}'
+          $fv=($ver.Split('.') + '0' + '0' + '0')[0..3] -join ','
+          ((Get-Content 'version-file-template.txt') -replace 'APP_NAME', $env:VIEWER_APPNAME -replace 'APP_VERSION', $ver -replace 'FILE_VERSION_COMMAS', $fv) |
+            Set-Content 'verinfo-viewer.txt' -Encoding UTF8
+          pyinstaller --noconfirm --windowed --onedir --noupx --clean --version-file verinfo-viewer.txt -n $env:VIEWER_APPNAME @iconArgs $env:VIEWER_ENTRY
           if (!(Test-Path "dist/$env:VIEWER_APPNAME")) { Write-Error "Viewer dist missing"; exit 1 }
 
       - name: Package ZIPs + latest.* for online installers
@@ -96,15 +104,19 @@ jobs:
 
           $ezip = "release/${env:EDITOR_APPNAME}-$ver-windows-x64.zip"
           Compress-Archive -Path "dist/${env:EDITOR_APPNAME}/*" -DestinationPath $ezip
+          if (!(Test-Path $ezip)) { Write-Error "Editor zip missing"; exit 1 }
           Copy-Item $ezip "release/latest-editor.zip" -Force
           $eh = (Get-FileHash "release/latest-editor.zip" -Algorithm SHA256).Hash.ToLower()
           "$eh  latest-editor.zip" | Out-File -Encoding ascii "release/latest-editor.sha256"
+          if (!(Test-Path "release/latest-editor.sha256")) { Write-Error "latest-editor.sha256 missing"; exit 1 }
 
           $vzip = "release/${env:VIEWER_APPNAME}-$ver-windows-x64.zip"
           Compress-Archive -Path "dist/${env:VIEWER_APPNAME}/*" -DestinationPath $vzip
+          if (!(Test-Path $vzip)) { Write-Error "Viewer zip missing"; exit 1 }
           Copy-Item $vzip "release/latest-viewer.zip" -Force
           $vh = (Get-FileHash "release/latest-viewer.zip" -Algorithm SHA256).Hash.ToLower()
           "$vh  latest-viewer.zip" | Out-File -Encoding ascii "release/latest-viewer.sha256"
+          if (!(Test-Path "release/latest-viewer.sha256")) { Write-Error "latest-viewer.sha256 missing"; exit 1 }
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
@@ -143,7 +155,7 @@ jobs:
 
       - name: Compile Editor Installer
         shell: pwsh
-        if: ${{ hashFiles('release/latest-editor.zip') != '' && hashFiles('installer.iss') != '' }}
+        if: ${{ hashFiles('release/latest-editor.zip') != '' && hashFiles('release/latest-editor.sha256') != '' && hashFiles('installer.iss') != '' }}
         run: |
           $ownerRepo = "${env:GITHUB_REPOSITORY}"
           $version='${{ steps.rtag.outputs.version }}'
@@ -151,18 +163,22 @@ jobs:
           $shaURL = "https://github.com/$ownerRepo/releases/latest/download/latest-editor.sha256"
           iscc /DMyAppName="${env:EDITOR_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:EDITOR_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" installer.iss
           New-Item -ItemType Directory -Force -Path release | Out-Null
-          Copy-Item ".\Output\${env:EDITOR_APPNAME}-Online-Setup.exe" "release/${env:EDITOR_APPNAME}-Online-Setup.exe" -Force
+          $outExe=".\Output\${env:EDITOR_APPNAME}-Online-Setup.exe"
+          if (!(Test-Path $outExe)) { Write-Error "Editor installer missing"; exit 1 }
+          Copy-Item $outExe "release/${env:EDITOR_APPNAME}-Online-Setup.exe" -Force
 
       - name: Compile Viewer Installer
         shell: pwsh
-        if: ${{ hashFiles('release/latest-viewer.zip') != '' && hashFiles('installer.iss') != '' }}
+        if: ${{ hashFiles('release/latest-viewer.zip') != '' && hashFiles('release/latest-viewer.sha256') != '' && hashFiles('installer.iss') != '' }}
         run: |
           $ownerRepo = "${env:GITHUB_REPOSITORY}"
           $version='${{ steps.rtag.outputs.version }}'
           $zipURL = "https://github.com/$ownerRepo/releases/latest/download/latest-viewer.zip"
           $shaURL = "https://github.com/$ownerRepo/releases/latest/download/latest-viewer.sha256"
           iscc /DMyAppName="${env:VIEWER_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:VIEWER_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" installer.iss
-          Copy-Item ".\Output\${env:VIEWER_APPNAME}-Online-Setup.exe" "release/${env:VIEWER_APPNAME}-Online-Setup.exe" -Force
+          $outExe=".\Output\${env:VIEWER_APPNAME}-Online-Setup.exe"
+          if (!(Test-Path $outExe)) { Write-Error "Viewer installer missing"; exit 1 }
+          Copy-Item $outExe "release/${env:VIEWER_APPNAME}-Online-Setup.exe" -Force
 
       - name: Upload installers
         if: always()

--- a/installer.iss
+++ b/installer.iss
@@ -27,7 +27,7 @@ SolidCompression=yes
 OutputBaseFilename={#MyAppName}-Online-Setup
 WizardStyle=modern
 ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x86 x64
+ArchitecturesAllowed=x64
 PrivilegesRequired=admin
 UninstallDisplayIcon={app}\{#MyAppExe}
 SetupLogging=yes
@@ -51,8 +51,8 @@ Filename: "{app}\{#MyAppExe}"; Description: "{#MyAppName} 실행"; Flags: nowait
 ; .bnov 확장자를 Branching Novel GUI에 연결
 Root: HKCR; Subkey: ".bnov"; ValueType: string; ValueName: ""; ValueData: "BranchingNovelFile"; Flags: uninsdeletevalue
 Root: HKCR; Subkey: "BranchingNovelFile"; ValueType: string; ValueName: ""; ValueData: "Branching Novel Script"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "BranchingNovelFile\DefaultIcon"; ValueType: string; ValueData: "{app}\BranchingNovelGUI.exe,0"
-Root: HKCR; Subkey: "BranchingNovelFile\shell\open\command"; ValueType: string; ValueData: """{app}\BranchingNovelGUI.exe"" ""%1"""
+Root: HKCR; Subkey: "BranchingNovelFile\DefaultIcon"; ValueType: string; ValueData: "{app}\{#MyAppExe},0"
+Root: HKCR; Subkey: "BranchingNovelFile\shell\open\command"; ValueType: string; ValueData: """{app}\{#MyAppExe}"" ""%1"""
 
 [Code]
 function IsPSAvailable(): Boolean;

--- a/version-file-template.txt
+++ b/version-file-template.txt
@@ -1,0 +1,24 @@
+# UTF-8
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(FILE_VERSION_COMMAS),
+    prodvers=(FILE_VERSION_COMMAS),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x4,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0,0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable('040904E4', [
+        StringStruct('FileDescription', 'APP_NAME'),
+        StringStruct('FileVersion', 'APP_VERSION'),
+        StringStruct('ProductName', 'APP_NAME'),
+        StringStruct('ProductVersion', 'APP_VERSION')
+      ])
+    ]),
+    VarFileInfo([VarStruct('Translation',[1033,1252])])
+  ]
+)


### PR DESCRIPTION
## Summary
- Embed version metadata when building Windows executables with PyInstaller and use `--onedir --noupx --clean`
- Validate release artifacts and require matching `latest-*.sha256` before generating installers
- Restrict Inno Setup installers to x64 and unify file association executable names

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca0b4d68832b8f0ff0bd8624f3af