### PR TITLE
fix: open variable autocomplete on dollar key

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -58,7 +58,7 @@ class VarAutocomplete:
         widget.bind("<FocusOut>", lambda e: self.close())
 
     def _on_key(self, event):
-        if event.char == "$":
+        if event.char == "$" or event.keysym == "dollar":
             self.open()
 
     def trigger(self):


### PR DESCRIPTION
## Summary
- ensure variable autocomplete dropdown opens when `$` is typed by handling the `dollar` keysym

## Testing
- `python -m py_compile branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8039b8e0c832bbeb68a45cccdea77