### PR TITLE
Fix variable autocompletion for dollar key

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -61,7 +61,11 @@ class VarAutocomplete:
         widget.bind("<FocusOut>", lambda e: self.close())
 
     def _on_key(self, event):
-        if event.char == "$" or event.keysym == "dollar":
+        if (
+            event.char == "$"
+            or event.keysym == "dollar"
+            or (event.keysym == "4" and event.state & 0x1)
+        ):
             self.open()
 
     def trigger(self):


### PR DESCRIPTION
## Summary
- Ensure `$` key triggers variable autocomplete

## Testing
- `python -m py_compile branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80d67507c832bacfa390c06f5b949