### PR TITLE
Support inline variable parsing

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -740,12 +740,23 @@ class BranchingNovelApp(tk.Tk):
         return state
 
     def _interpolate(self, text: str) -> str:
-        pattern = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
-        def repl(m: re.Match[str]) -> str:
-            var = m.group(1)
-            val = self.state.get(var, self.story.variables.get(var, ""))
-            return str(val)
-        return pattern.sub(repl, text)
+        if not text:
+            return ""
+        vars_list = sorted(self.story.variables.keys(), key=len, reverse=True)
+        result: List[str] = []
+        idx = 0
+        length = len(text)
+        while idx < length:
+            for name in vars_list:
+                if text.startswith(name, idx):
+                    val = self.state.get(name, self.story.variables.get(name, ""))
+                    result.append(str(val))
+                    idx += len(name)
+                    break
+            else:
+                result.append(text[idx])
+                idx += 1
+        return "".join(result)
 
     def _evaluate_condition(self, cond: str) -> bool:
         expr = self._to_python_expr(cond)


### PR DESCRIPTION
## Summary
- detect variables embedded within other text during editing
- replace variable names in titles, choices, and passages without requiring ${}

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py`
- `python - <<'PY'
from branching_novel import BranchingNovelApp, Story
app = BranchingNovelApp.__new__(BranchingNovelApp)
app.story = Story(variables={'qwerty':1,'tyuiop':2,'iopasd':3})
app.state = {}
print(app._interpolate('qwertyuiopasd'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b8ff6c0f2c832ba3f3537fbc0722da