### PR TITLE
Fix variable highlight edge cases

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -544,7 +544,7 @@ def highlight_variables(widget: tk.Text, get_vars: Callable[[], Iterable[str]]) 
                 widget.tag_add("var", start_pos, end_pos)
                 i = j + 2
                 continue
-            i = j + 2 if j != -1 else i + 2
+            i += 1
         else:
             i += 1
 


### PR DESCRIPTION
## Summary
- Avoid skipping subsequent variables when encountering unmatched `__`
- Ensure variable highlighting works when variables touch other text

## Testing
- `python -m py_compile branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90c128790832b87e41ad94863427a