### PR TITLE
Fix variable token parsing and highlighting

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -454,25 +454,23 @@ class BranchingNovelApp(tk.Tk):
         if not text:
             return ""
 
-        result = []
+        # Precompute variable names for quick matching.  We sort by length so that
+        # longer variable names take precedence when names share prefixes.
+        variables = {**self.story.variables, **self.state}
+        var_names = sorted(variables.keys(), key=len, reverse=True)
+
+        result: List[str] = []
         i = 0
         while i < len(text):
+            matched = False
             if text.startswith("__", i):
-                j = text.find("__", i + 2)
-                name = text[i + 2 : j] if j != -1 else ""
-                if j != -1 and name and re.fullmatch(r"[A-Za-z0-9_]+", name):
-                    token = f"__{name}__"
-                    if token in self.state:
-                        result.append(str(self.state[token]))
-                    elif token in self.story.variables:
-                        result.append(str(self.story.variables[token]))
-                    else:
-                        result.append(token)
-                    i = j + 2
-                    continue
-                result.append("__")
-                i += 2
-            else:
+                for name in var_names:
+                    if text.startswith(name, i):
+                        result.append(str(variables[name]))
+                        i += len(name)
+                        matched = True
+                        break
+            if not matched:
                 result.append(text[i])
                 i += 1
 

--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -522,30 +522,29 @@ class VarAutocomplete:
         self._is_filtering = False
 
 def highlight_variables(widget: tk.Text, get_vars: Callable[[], Iterable[str]]) -> None:
-    """Text 위젯에서 실제 변수만 하이라이팅"""
+    """Highlight only defined variables in a Text widget."""
     try:
         widget.tag_remove("var", "1.0", tk.END)
     except tk.TclError:
         return
-    vars_set = set(get_vars()) if get_vars else set()
-    if not vars_set:
+
+    vars_list = sorted(set(get_vars()), key=len, reverse=True) if get_vars else []
+    if not vars_list:
         return
 
     text = widget.get("1.0", "end-1c")
     i = 0
     while i < len(text):
-        if text.startswith("__", i):
-            j = text.find("__", i + 2)
-            name = text[i + 2 : j] if j != -1 else ""
-            token = text[i : j + 2] if j != -1 else ""
-            if j != -1 and name and re.fullmatch(r"[A-Za-z0-9_]+", name) and token in vars_set:
+        matched = False
+        for name in vars_list:
+            if text.startswith(name, i):
                 start_pos = f"1.0+{i}c"
-                end_pos = f"1.0+{j + 2}c"
+                end_pos = f"1.0+{i + len(name)}c"
                 widget.tag_add("var", start_pos, end_pos)
-                i = j + 2
-                continue
-            i += 1
-        else:
+                i += len(name)
+                matched = True
+                break
+        if not matched:
             i += 1
 
     # 변수 스타일 설정


### PR DESCRIPTION
## Summary
- Make interpolation detect variables by matching known tokens sequentially
- Update editor variable highlighting to mirror new parsing logic

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py story_parser.py`
- `python - <<'PY'
from branching_novel import BranchingNovelApp, Story
bn = BranchingNovelApp.__new__(BranchingNovelApp)
bn.story = Story(); bn.state = {}
bn.story.variables['__asd__']=23
print(bn._interpolate('__asdf__asd__'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b90d8fee00832bb9fde14ffc510356