### PR TITLE
Allow unquoted strings for variable initial values

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1283,8 +1283,8 @@ class VariableDialog(tk.Toplevel):
                 try:
                     val = float(val_text)
                 except ValueError:
-                    messagebox.showerror(tr("error"), tr("invalid_initial_value"))
-                    return
+                    # Allow plain strings without quotes
+                    val = val_text
         if not (name.startswith("__") and name.endswith("__")):
             core = name.strip("_")
             name = f"__{core}__"


### PR DESCRIPTION
## Summary
- Permit plain, unquoted strings when setting initial variable values in the editor

## Testing
- `python -m py_compile branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90e794294832babf5279fb8c8470f