### PR TITLE
Fix variable interpolation for __var__ placeholders

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -454,23 +454,25 @@ class BranchingNovelApp(tk.Tk):
         if not text:
             return ""
 
-        # Precompute variable names for quick matching.  We sort by length so that
-        # longer variable names take precedence when names share prefixes.
+        # Variables can be embedded in text using ``__var__`` syntax.  We scan for
+        # that pattern and replace it with the current value.  This logic mirrors
+        # the editor's interpolation so both behave consistently.
         variables = {**self.story.variables, **self.state}
-        var_names = sorted(variables.keys(), key=len, reverse=True)
 
         result: List[str] = []
         i = 0
         while i < len(text):
-            matched = False
             if text.startswith("__", i):
-                for name in var_names:
-                    if text.startswith(name, i):
-                        result.append(str(variables[name]))
-                        i += len(name)
-                        matched = True
-                        break
-            if not matched:
+                j = text.find("__", i + 2)
+                name = text[i + 2 : j] if j != -1 else ""
+                if j != -1 and name in variables:
+                    result.append(str(variables[name]))
+                    i = j + 2
+                    continue
+                # Unmatched opening ``__`` – treat as literal characters.
+                result.append("__")
+                i += 2
+            else:
                 result.append(text[i])
                 i += 1
 

--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -942,16 +942,17 @@ class BranchingNovelApp(tk.Tk):
             if text.startswith("__", i):
                 j = text.find("__", i + 2)
                 name = text[i + 2 : j] if j != -1 else ""
-                if j != -1 and name and re.fullmatch(r"[A-Za-z0-9_]+", name):
-                    token = f"__{name}__"
-                    if token in self.state:
-                        result.append(str(self.state[token]))
-                    elif token in self.story.variables:
-                        result.append(str(self.story.variables[token]))
-                    else:
-                        result.append(token)
-                    i = j + 2
-                    continue
+                if j != -1 and name:
+                    if name in self.state:
+                        result.append(str(self.state[name]))
+                        i = j + 2
+                        continue
+                    if name in self.story.variables:
+                        result.append(str(self.story.variables[name]))
+                        i = j + 2
+                        continue
+                # Either no closing ``__`` or unknown variable; treat the leading
+                # ``__`` as literal and continue scanning.
                 result.append("__")
                 i += 2
             else:


### PR DESCRIPTION
## Summary
- Fix `_interpolate` in branching_novel to correctly replace `__var__` placeholders with variable values
- Align editor `_interpolate` logic with runtime, handling unknown variables and literals consistently

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py story_parser.py`
- `python - <<'PY'
from branching_novel import BranchingNovelApp, Story
app = object.__new__(BranchingNovelApp)
app.story = Story()
app.story.variables['var1'] = 2
app.state = {}
print(app._interpolate('__text__var1__'))
print(app._interpolate('__var1__'))
print(app._interpolate('value: __var1__!'))
PY`
- `python - <<'PY'
from branching_novel_editor import BranchingNovelApp, Story
editor = object.__new__(BranchingNovelApp)
editor.story = Story()
editor.story.variables['var1']=2
editor.state = {}
print(editor._interpolate('__text__var1__'))
print(editor._interpolate('__var1__'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b910abf080832bb1691040306ae357