### PR TITLE
Restrict double underscores to text placeholders

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -456,7 +456,9 @@ class BranchingNovelApp(tk.Tk):
 
         # Variables can be embedded in text using ``__var__`` syntax.  We scan for
         # that pattern and replace it with the current value.  This logic mirrors
-        # the editor's interpolation so both behave consistently.
+        # the editor's interpolation so both behave consistently.  Variable names
+        # themselves are stored without surrounding underscores, so only the
+        # inner portion of the placeholder is used for lookups.
         variables = {**self.story.variables, **self.state}
 
         result: List[str] = []
@@ -465,11 +467,6 @@ class BranchingNovelApp(tk.Tk):
             if text.startswith("__", i):
                 j = text.find("__", i + 2)
                 if j != -1:
-                    placeholder = text[i : j + 2]
-                    if placeholder in variables:
-                        result.append(str(variables[placeholder]))
-                        i = j + 2
-                        continue
                     name = text[i + 2 : j]
                     if name in variables:
                         result.append(str(variables[name]))

--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -472,15 +472,6 @@ class BranchingNovelApp(tk.Tk):
             if text.startswith("__", i):
                 j = text.find("__", i + 2)
                 if j != -1:
-                    placeholder = text[i : j + 2]
-                    if placeholder in self.state:
-                        result.append(str(self.state[placeholder]))
-                        i = j + 2
-                        continue
-                    if placeholder in self.story.variables:
-                        result.append(str(self.story.variables[placeholder]))
-                        i = j + 2
-                        continue
                     name = text[i + 2 : j]
                     if name in self.state:
                         result.append(str(self.state[name]))


### PR DESCRIPTION
## Summary
- Tighten interpolation logic so `__var__` placeholders map to `var` only
- Mirror placeholder handling in editor to avoid treating `__var__` as a variable name

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b952fd17d0832b9142659466a74f57