### PR TITLE
feat: add scrolling for long chapter titles

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -198,6 +198,10 @@ class BranchingNovelApp(tk.Tk):
         self.bind("<Right>", self._go_next_chapter)
 
     def _populate_chapter_list(self):
+        if self._marquee_job:
+            self.after_cancel(self._marquee_job)
+            self._marquee_job = None
+        self._marquee_items = []
         # 리스트 업데이트 시 일시적으로 활성화
         self.chapter_list.configure(state="normal")
         self.chapter_list.delete(0, tk.END)


### PR DESCRIPTION
## Summary
- animate long chapter titles in the chapter list so they scroll and pause before looping
- measure text width using tk fonts and schedule marquee updates
- cancel pending chapter marquee updates before clearing the list

## Testing
- `python -m py_compile branching_novel.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b95d09a128832b922010f4896361a3