### PR TITLE
Fix missing marquee effect for long chapter titles

### DIFF
--- a/branching_novel.py
+++ b/branching_novel.py
@@ -218,6 +218,8 @@ class BranchingNovelApp(tk.Tk):
         if self._marquee_job:
             self.after_cancel(self._marquee_job)
             self._marquee_job = None
+        # make sure geometry info is up-to-date before measuring width
+        self.chapter_list.update_idletasks()
         width = self.chapter_list.winfo_width()
         if width <= 1:
             # widget not yet rendered; try again shortly


### PR DESCRIPTION
## Summary
- ensure chapter list geometry is updated before measuring width so long titles trigger marquee scrolling

## Testing
- `python -m py_compile branching_novel.py`

------
https://chatgpt.com/codex/tasks/task_e_68b95d85ed44832ba749bb3337908c14