### PR TITLE
Fix chapter list marquee spacing

### DIFF
--- a/branching_novel_app.py
+++ b/branching_novel_app.py
@@ -179,10 +179,11 @@ class BranchingNovelApp(tk.Tk):
             if item["pause"] > 0:
                 item["pause"] -= 1
                 continue
+            # advance offset before rendering so the loop completes
+            item["offset"] = (item["offset"] + 1) % len(full)
             display = full[item["offset"]:] + full[: item["offset"]]
             self.chapter_list.delete(item["index"])
             self.chapter_list.insert(item["index"], display)
-            item["offset"] = (item["offset"] + 1) % len(full)
             if item["offset"] == 0:
                 item["pause"] = self._marquee_pause_cycles
         if sel:


### PR DESCRIPTION
## Summary
- prevent leading space after chapter title scroll completes

## Testing
- `python3 -m py_compile branching_novel_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b961c14450832b9483ffb174a1cdb1