### PR TITLE
Cancel marquee timer when closing window

### DIFF
--- a/branching_novel_app.py
+++ b/branching_novel_app.py
@@ -130,6 +130,13 @@ class BranchingNovelApp(tk.Tk):
     def _bind_events(self):
         self.bind("<Left>", self._go_prev_chapter)
         self.bind("<Right>", self._go_next_chapter)
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _on_close(self):
+        if self._marquee_job:
+            self.after_cancel(self._marquee_job)
+            self._marquee_job = None
+        self.destroy()
 
     def _populate_chapter_list(self):
         if self._marquee_job:


### PR DESCRIPTION
## Summary
- Stop the chapter title marquee when the window closes to prevent Tkinter "after" callbacks from running after destroy

## Testing
- `python -m py_compile branching_novel_app.py branching_novel.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98e71403c832b834f200461657ef8