### PR TITLE
Handle sliding underscores for partial variable tokens

### DIFF
--- a/branching_novel_app.py
+++ b/branching_novel_app.py
@@ -484,9 +484,9 @@ class BranchingNovelApp(tk.Tk):
             k = j + 2
             m = re.match(r"([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)", s[k:])
             if not m:
-                # 식별자 없으면 '__' 자체를 리터럴로 취급
-                out_parts.append("__")
-                i = k
+                # 슬라이딩: '___var__'처럼 '__' 뒤에 식별자가 없으면 '_'만 소비하고 한 칸 전진
+                out_parts.append("_")
+                i = j + 1
                 continue
 
             name = m.group(1)
@@ -504,9 +504,9 @@ class BranchingNovelApp(tk.Tk):
                     out_parts.append(s[j:k])
                     i = k
             else:
-                # 닫힘 '__' 없으면 앞의 '__'는 리터럴
-                out_parts.append("__")
-                i = j + 2
+                # 슬라이딩: 닫힘 '__'가 없으면 '_'만 소비하고 한 칸 전진
+                out_parts.append("_")
+                i = j + 1
 
         return "".join(out_parts)
 

--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -75,7 +75,8 @@ def highlight_variables(widget: tk.Text, get_vars: Callable[[], Iterable[str]]) 
         k = j + 2
         m = re.match(r"([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)", text[k:])
         if not m:
-            i = k
+            # 슬라이딩: '___var__'처럼 '__' 뒤에 식별자가 없으면 '_'만 소비
+            i = j + 1
             continue
 
         name = m.group(1)
@@ -89,7 +90,8 @@ def highlight_variables(widget: tk.Text, get_vars: Callable[[], Iterable[str]]) 
             # 정의 여부에 따라 소비 범위 결정
             i = k + 2 if name in vars_set else k
         else:
-            i = j + 2
+            # 슬라이딩: 닫힘 '__'가 없으면 '_'만 소비
+            i = j + 1
 
     # 변수 스타일 설정
     base_font = tkfont.Font(font=widget.cget("font"))


### PR DESCRIPTION
## Summary
- slide through malformed `__var__` tokens so `___name__` becomes `_<value>` instead of literal `__`
- mirror sliding logic in editor's variable highlight so scanning matches runtime

## Testing
- `python -m py_compile branching_novel_app.py branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9955b3d1c832ba13eb863cb270656