### PR TITLE
Localize .bnov file association installer task

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -43,9 +43,13 @@ UsePreviousLanguage=no
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "korean"; MessagesFile: "compiler:Languages\Korean.isl"
 
+[CustomMessages]
+english.AssociateBnov=Associate .bnov files with {#MyAppName}
+korean.AssociateBnov=.bnov 파일을 {#MyAppName}에 연결
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "fileassoc"; Description: "Associate .bnov files with {#MyAppName}"; Flags: checkedonce
+Name: "fileassoc"; Description: "{cm:AssociateBnov}"; Flags: checkedonce
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExe}"


### PR DESCRIPTION
## Summary
- localize the installer task for associating .bnov files by adding custom messages and referencing them in the task description

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68ba359bc000832bbefe824199b72716