### PR TITLE
Update Inno Setup architecture ID to x64compatible

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -28,8 +28,9 @@ ChangesAssociations=yes
 SolidCompression=yes
 OutputBaseFilename={#MyAppName}-Online-Setup
 WizardStyle=modern
-ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x64
+; Use the modern 64-bit identifier to avoid deprecation warnings.
+ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
 PrivilegesRequired=admin
 UninstallDisplayIcon={app}\{#MyAppExe}
 SetupLogging=yes


### PR DESCRIPTION
## Summary
- use new `x64compatible` identifier to avoid `x64` deprecation warnings

## Testing
- `iscc installer.iss` *(fails: command not found)*
- `python -m py_compile branching_novel.py story_parser.py auto_update.py branching_novel_app.py branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba35c19fe8832b8023b2db51e65a5a