### PR TITLE
Separate editor and game installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,13 +185,13 @@ jobs:
 
       - name: Compile Editor Installer
         shell: pwsh
-        if: ${{ hashFiles('release/latest-editor.zip') != '' && hashFiles('release/latest-editor.sha256') != '' && hashFiles('installer.iss') != '' }}
+        if: ${{ hashFiles('release/latest-editor.zip') != '' && hashFiles('release/latest-editor.sha256') != '' && hashFiles('editor_installer.iss') != '' }}
         run: |
           $ownerRepo = "${env:GITHUB_REPOSITORY}"
           $version='${{ steps.rtag.outputs.version }}'
           $zipURL = "https://github.com/$ownerRepo/releases/latest/download/latest-editor.zip"
           $shaURL = "https://github.com/$ownerRepo/releases/latest/download/latest-editor.sha256"
-          iscc /DMyAppName="${env:EDITOR_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:EDITOR_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" installer.iss
+          iscc /DMyAppName="${env:EDITOR_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:EDITOR_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" editor_installer.iss
           New-Item -ItemType Directory -Force -Path release | Out-Null
           $outExe=".\Output\${env:EDITOR_APPNAME}-Online-Setup.exe"
           if (!(Test-Path $outExe)) { Write-Error "Editor installer missing"; exit 1 }
@@ -199,13 +199,13 @@ jobs:
 
       - name: Compile Viewer Installer
         shell: pwsh
-        if: ${{ hashFiles('release/latest-viewer.zip') != '' && hashFiles('release/latest-viewer.sha256') != '' && hashFiles('installer.iss') != '' }}
+        if: ${{ hashFiles('release/latest-viewer.zip') != '' && hashFiles('release/latest-viewer.sha256') != '' && hashFiles('game_installer.iss') != '' }}
         run: |
           $ownerRepo = "${env:GITHUB_REPOSITORY}"
           $version='${{ steps.rtag.outputs.version }}'
           $zipURL = "https://github.com/$ownerRepo/releases/latest/download/latest-viewer.zip"
           $shaURL = "https://github.com/$ownerRepo/releases/latest/download/latest-viewer.sha256"
-          iscc /DMyAppName="${env:VIEWER_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:VIEWER_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" installer.iss
+          iscc /DMyAppName="${env:VIEWER_APPNAME}" /DMyAppVersion="$version" /DMyAppExe="${env:VIEWER_EXE}" /DPayloadZipURL="$zipURL" /DPayloadShaURL="$shaURL" game_installer.iss
           $outExe=".\Output\${env:VIEWER_APPNAME}-Online-Setup.exe"
           if (!(Test-Path $outExe)) { Write-Error "Viewer installer missing"; exit 1 }
           Copy-Item $outExe "release/${env:VIEWER_APPNAME}-Online-Setup.exe" -Force

--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ You wake up with __coins__ coins.
 ```
 python branching_novel.py path/to/story.bnov
 ```
+
+## Building installers
+
+Use `editor_installer.iss` to build the editor installer and `game_installer.iss` for the game. Each wrapper defines its own payload and only writes the language file it needs, while sharing common logic from `installer.iss`.

--- a/editor_installer.iss
+++ b/editor_installer.iss
@@ -1,0 +1,18 @@
+#ifndef MyAppName
+#define MyAppName "Branching Novel Editor"
+#endif
+#ifndef MyAppVersion
+#define MyAppVersion "0.0.0"
+#endif
+#ifndef MyAppExe
+#define MyAppExe "BranchingNovelEditor.exe"
+#endif
+#ifndef PayloadZipURL
+#define PayloadZipURL "https://example.com/editor_latest.zip"
+#endif
+#ifndef PayloadShaURL
+#define PayloadShaURL "https://example.com/editor_latest.sha256"
+#endif
+#define InstallEditor 1
+#define InstallGame 0
+#include "installer.iss"

--- a/game_installer.iss
+++ b/game_installer.iss
@@ -1,0 +1,18 @@
+#ifndef MyAppName
+#define MyAppName "Branching Novel"
+#endif
+#ifndef MyAppVersion
+#define MyAppVersion "0.0.0"
+#endif
+#ifndef MyAppExe
+#define MyAppExe "BranchingNovel.exe"
+#endif
+#ifndef PayloadZipURL
+#define PayloadZipURL "https://example.com/game_latest.zip"
+#endif
+#ifndef PayloadShaURL
+#define PayloadShaURL "https://example.com/game_latest.sha256"
+#endif
+#define InstallEditor 0
+#define InstallGame 1
+#include "installer.iss"

--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,11 @@
 ; installer.iss - Online Bootstrap Installer
 
+#ifndef InstallEditor
+  #define InstallEditor 1
+#endif
+#ifndef InstallGame
+  #define InstallGame 1
+#endif
 #ifndef MyAppName
   #define MyAppName "MyApp"
 #endif
@@ -50,7 +56,9 @@ korean.AssociateBnov=.bnov 파일을 {#MyAppName}에 연결
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+#if InstallEditor
 Name: "fileassoc"; Description: "{cm:AssociateBnov}"; Flags: checkedonce
+#endif
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExe}"
@@ -61,6 +69,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExe}"; Tasks: deskto
 Filename: "{app}\{#MyAppExe}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
 
 [Registry]
+#if InstallEditor
 ; ----------
 ; 파일 연결(ProgID) - 관리자 설치: HKCR/HKLM
 ; ----------
@@ -92,6 +101,7 @@ Root: HKCU; Subkey: "Software\RegisteredApplications"; ValueType: string; ValueN
 Root: HKCU; Subkey: "Software\{#MyAppName}\Capabilities"; ValueType: string; ValueName: "ApplicationName"; ValueData: "{#MyAppName}"; Check: not IsAdminLoggedOn
 Root: HKCU; Subkey: "Software\{#MyAppName}\Capabilities"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "{#MyAppName} can open Branching Novel Script files (.bnov)"; Check: not IsAdminLoggedOn
 Root: HKCU; Subkey: "Software\{#MyAppName}\Capabilities\FileAssociations"; ValueType: string; ValueName: ".bnov"; ValueData: "BranchingNovelFile"; Check: not IsAdminLoggedOn
+#endif
 
 ; ----------
 ; 업데이트용: 버전 정보를 고정 경로(HKCU)에 저장
@@ -401,7 +411,11 @@ begin
 
     Base := ExpandConstant('{app}\');
     SaveStringToFile(Base + 'language.txt', Lang, False);
+#if InstallEditor
     SaveStringToFile(Base + 'editor_language.txt', Lang, False);
+#endif
+#if InstallGame
     SaveStringToFile(Base + 'game_language.txt', Lang, False);
+#endif
   end;
 end;


### PR DESCRIPTION
## Summary
- allow conditional editor and game installs via `InstallEditor` and `InstallGame` macros
- add `editor_installer.iss` and `game_installer.iss` wrappers that include the shared installer
- document how to build each installer separately in README
- use installer wrappers in CI workflow

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py branching_novel_app.py i18n.py auto_update.py story_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba6fa1c09c832baea95ef10ce52705