### PR TITLE
Separate editor and game installers

### DIFF
--- a/editor_installer.iss
+++ b/editor_installer.iss
@@ -13,6 +13,9 @@
 #ifndef PayloadShaURL
 #define PayloadShaURL "https://example.com/editor_latest.sha256"
 #endif
+#ifndef MyAppId
+#define MyAppId "{{667FEBC7-64DB-446E-97B5-E6886D5E4660}}"
+#endif
 #define InstallEditor 1
 #define InstallGame 0
 #include "installer.iss"

--- a/game_installer.iss
+++ b/game_installer.iss
@@ -13,6 +13,9 @@
 #ifndef PayloadShaURL
 #define PayloadShaURL "https://example.com/game_latest.sha256"
 #endif
+#ifndef MyAppId
+#define MyAppId "{{0FD4DF37-F7B3-40B1-8715-9667977A8D51}}"
+#endif
 #define InstallEditor 0
 #define InstallGame 1
 #include "installer.iss"

--- a/installer.iss
+++ b/installer.iss
@@ -21,9 +21,12 @@
 #ifndef PayloadShaURL
   #define PayloadShaURL "https://example.com/latest.sha256"
 #endif
+#ifndef MyAppId
+  #define MyAppId "{{B1C50C47-7B73-4308-9C74-2A9B3E11A9D3}}"
+#endif
 
 [Setup]
-AppId={{B1C50C47-7B73-4308-9C74-2A9B3E11A9D3}}
+AppId={#MyAppId}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 DefaultDirName={autopf}\{#MyAppName}


### PR DESCRIPTION
## Summary
- allow conditional editor and game installs via `InstallEditor` and `InstallGame` macros
- add `editor_installer.iss` and `game_installer.iss` wrappers that include the shared installer
- document how to build each installer separately in README
- use installer wrappers in CI workflow
- assign unique `AppId` values for editor and game installers

## Testing
- `python -m py_compile branching_novel.py branching_novel_editor.py branching_novel_app.py i18n.py auto_update.py story_parser.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68ba73e9a804832b926ed1906298ff2d