### PR TITLE
Use GitHub API for installer payloads

### DIFF
--- a/editor_installer.iss
+++ b/editor_installer.iss
@@ -1,17 +1,11 @@
 #ifndef MyAppName
 #define MyAppName "Branching Novel Editor"
 #endif
-#ifndef MyAppVersion
-#define MyAppVersion "0.0.0"
-#endif
 #ifndef MyAppExe
 #define MyAppExe "BranchingNovelEditor.exe"
 #endif
-#ifndef PayloadZipURL
-#define PayloadZipURL "https://example.com/editor_latest.zip"
-#endif
-#ifndef PayloadShaURL
-#define PayloadShaURL "https://example.com/editor_latest.sha256"
+#ifndef ReleaseAssetPattern
+#define ReleaseAssetPattern "editor"
 #endif
 #ifndef MyAppId
 #define MyAppId "{{667FEBC7-64DB-446E-97B5-E6886D5E4660}}"

--- a/game_installer.iss
+++ b/game_installer.iss
@@ -1,17 +1,11 @@
 #ifndef MyAppName
 #define MyAppName "Branching Novel"
 #endif
-#ifndef MyAppVersion
-#define MyAppVersion "0.0.0"
-#endif
 #ifndef MyAppExe
 #define MyAppExe "BranchingNovel.exe"
 #endif
-#ifndef PayloadZipURL
-#define PayloadZipURL "https://example.com/game_latest.zip"
-#endif
-#ifndef PayloadShaURL
-#define PayloadShaURL "https://example.com/game_latest.sha256"
+#ifndef ReleaseAssetPattern
+#define ReleaseAssetPattern "game"
 #endif
 #ifndef MyAppId
 #define MyAppId "{{0FD4DF37-F7B3-40B1-8715-9667977A8D51}}"


### PR DESCRIPTION
## Summary
- Resolve latest GitHub release to set installer version and payload URLs
- Editor and game installers specify asset filters for dynamic lookup

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba76a43eac832bacbc7943d7d0da7c