### PR TITLE
Fix type mismatch in installer script

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -253,7 +253,8 @@ end;
 
 function ResolveLatestRelease(const LogPath: String): Boolean;
 var
-  Cmd, OutPath, Content, Part: String;
+  Cmd, OutPath, Part: String;
+  ContentAnsi: AnsiString;
 begin
   if GPayloadZipURL <> '' then
   begin
@@ -275,9 +276,9 @@ begin
     'Set-Content -LiteralPath ' + PSQuote(OutPath) + ' -Value $out -Encoding UTF8;';
   if not WriteAndRunPS(Cmd, LogPath, 'github_latest') then
     Exit;
-  if not LoadStringFromFile(OutPath, Content) then
+  if not LoadStringFromFile(OutPath, ContentAnsi) then
     Exit;
-  Part := Content;
+  Part := ContentAnsi;
   if Pos('|', Part) = 0 then Exit;
   GLatestVersion := Copy(Part, 1, Pos('|', Part) - 1);
   Delete(Part, 1, Pos('|', Part));


### PR DESCRIPTION
## Summary
- fix type mismatch when loading latest release metadata in installer

## Testing
- `iscc installer.iss` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba79517d28832b96261cfcc26188a5