### PR TITLE
Ensure installer uses platform-specific SHA files

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -277,8 +277,10 @@ begin
     '$tag = $json.tag_name; ' +
     '$ver = if($tag -and $tag.StartsWith("v")) { $tag.Substring(1) } else { $tag }; ' +
     '$zip = $json.assets | Where-Object { $_.name -like ' + PSQuote('{#ReleaseAssetPattern}*.zip') + ' } | Select-Object -First 1; ' +
-    '$sha = $json.assets | Where-Object { $_.name -like ' + PSQuote('{#ReleaseAssetPattern}*.sha256') + ' } | Select-Object -First 1; ' +
-    'if (($null -eq $zip) -or ($null -eq $sha)) { throw ' + PSQuote('Release asset not found') + ' }; ' +
+    'if ($null -eq $zip) { throw ' + PSQuote('Zip asset not found') + ' }; ' +
+    '$shaName = $zip.name -replace ''\.zip$'', ''.sha256''; ' +
+    '$sha = $json.assets | Where-Object { $_.name -eq $shaName } | Select-Object -First 1; ' +
+    'if ($null -eq $sha) { throw ' + PSQuote('SHA asset not found') + ' }; ' +
     '$out = @($ver, $zip.browser_download_url, $sha.browser_download_url) -join "|"; ' +
     'Set-Content -LiteralPath ' + PSQuote(OutPath) + ' -Value $out -Encoding ASCII;';
   if not WriteAndRunPS(Cmd, LogPath, 'github_latest') then


### PR DESCRIPTION
## Summary
- Ensure the installer chooses the matching `.sha256` asset for each platform zip when resolving latest release

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `pwsh -Command "Write-Host test"` *(PowerShell not installed; unable to rerun installer for hash verification)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9db2087c832b9cab89d83382fe36