### PR TITLE
Apply installer language choice to app

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -2,12 +2,20 @@ import os
 
 _DEFAULT_LANG = 'en'
 _DEFAULT_LANG_FILE = os.path.join(os.path.dirname(__file__), 'language.txt')
+# 지원되는 언어 코드와 별칭 맵핑
+_LANG_ALIASES = {
+    'en': 'en',
+    'english': 'en',
+    'korean': 'korean',
+    'ko': 'korean',
+}
 
 
 def _load_lang_from_file(path: str) -> str:
     try:
         with open(path, encoding='utf-8') as f:
-            return f.read().strip() or _DEFAULT_LANG
+            lang = f.read().strip().lower()
+            return _LANG_ALIASES.get(lang, _DEFAULT_LANG)
     except OSError:
         return _DEFAULT_LANG
 

--- a/installer.iss
+++ b/installer.iss
@@ -500,7 +500,7 @@ begin
     UpdateVersionFromExe(LogPath);
 
     if ActiveLanguage = 'korean' then
-      Lang := 'ko'
+      Lang := 'korean'
     else
       Lang := 'en';
 


### PR DESCRIPTION
## Summary
- map `ko` to `korean` and default unknown language codes to English
- installer writes `korean` instead of `ko` to language files

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baaa8de3e0832bbd51ad38e773d9be