### PR TITLE
Use tag-based release assets with cache busting

### DIFF
--- a/auto_update.py
+++ b/auto_update.py
@@ -8,6 +8,7 @@ import platform
 import subprocess
 import tempfile
 import urllib.request
+import uuid
 from tkinter import messagebox
 
 from i18n import tr
@@ -274,6 +275,8 @@ def check_for_update(
         asset_url = _pick_asset_download_url(data, installer_name)
         if not asset_url:
             return
+
+        asset_url = f"{asset_url}?cb={uuid.uuid4()}"
 
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".exe")
         tmp.close()


### PR DESCRIPTION
## Summary
- Resolve latest release assets by tag via GitHub API and build direct asset URLs
- Append cache-busting query parameters when downloading release assets
- Prevent updater from using cached installers by adding UUID-based query parameter

## Testing
- `python -m py_compile auto_update.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba803e5e0832b848a89c86bb96352