### PR TITLE
Use release tag as cache buster

### DIFF
--- a/auto_update.py
+++ b/auto_update.py
@@ -8,7 +8,6 @@ import platform
 import subprocess
 import tempfile
 import urllib.request
-import uuid
 from tkinter import messagebox
 
 from i18n import tr
@@ -276,7 +275,7 @@ def check_for_update(
         if not asset_url:
             return
 
-        asset_url = f"{asset_url}?cb={uuid.uuid4()}"
+        asset_url = f"{asset_url}?cb={tag}"
 
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".exe")
         tmp.close()

--- a/installer.iss
+++ b/installer.iss
@@ -323,8 +323,8 @@ begin
   Cmd :=
     '$ErrorActionPreference = ''Stop''; ' +
     '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ' +
-    'Invoke-WebRequest -Uri (' + PSQuote(UrlZip) + ' + ' + PSQuote('?cb=') + ' + [Guid]::NewGuid().ToString()) -OutFile ' + PSQuote(DestZip) + '; ' +
-    'Invoke-WebRequest -Uri (' + PSQuote(UrlSha) + ' + ' + PSQuote('?cb=') + ' + [Guid]::NewGuid().ToString()) -OutFile ' + PSQuote(DestSha) + '; ' +
+    'Invoke-WebRequest -Uri (' + PSQuote(UrlZip) + ' + ' + PSQuote('?cb=') + ' + ' + PSQuote(GLatestVersion) + ') -OutFile ' + PSQuote(DestZip) + '; ' +
+    'Invoke-WebRequest -Uri (' + PSQuote(UrlSha) + ' + ' + PSQuote('?cb=') + ' + ' + PSQuote(GLatestVersion) + ') -OutFile ' + PSQuote(DestSha) + '; ' +
     '$expected = (Get-Content -LiteralPath ' + PSQuote(DestSha) + ' | Select-Object -First 1).Split('' '')[0]; ' +
     'if ([string]::IsNullOrWhiteSpace($expected)) { throw ''Empty SHA file'' } ' +
     '$actual = (Get-FileHash -LiteralPath ' + PSQuote(DestZip) + ' -Algorithm SHA256).Hash.ToLower(); ' +


### PR DESCRIPTION
## Summary
- Use GitHub release tag for the cache-busting query when downloading updates
- Propagate resolved release version to installer download verification

## Testing
- `python -m py_compile auto_update.py`
- `iscc /Qp installer.iss` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd147b6c8832b931c10b9b950136a