### PR TITLE
Handle BOM in SHA verification

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -326,6 +326,7 @@ begin
     'Invoke-WebRequest -Uri (' + PSQuote(UrlZip) + ' + ' + PSQuote('?cb=') + ' + [Guid]::NewGuid().ToString()) -OutFile ' + PSQuote(DestZip) + '; ' +
     'Invoke-WebRequest -Uri (' + PSQuote(UrlSha) + ' + ' + PSQuote('?cb=') + ' + [Guid]::NewGuid().ToString()) -OutFile ' + PSQuote(DestSha) + '; ' +
     '$expected = (Get-Content -LiteralPath ' + PSQuote(DestSha) + ' | Select-Object -First 1).Split('' '')[0]; ' +
+    '$expected = $expected.Trim([char]0xFEFF); ' +
     'if ([string]::IsNullOrWhiteSpace($expected)) { throw ''Empty SHA file'' } ' +
     '$actual = (Get-FileHash -LiteralPath ' + PSQuote(DestZip) + ' -Algorithm SHA256).Hash.ToLower(); ' +
     'if ($expected.ToLower() -ne $actual) { throw (''Hash mismatch. Expected: '' + $expected + '', Actual: '' + $actual) }';


### PR DESCRIPTION
## Summary
- Trim UTF-8 BOM from expected SHA value during download verification
- Preserve existing first-token comparison after BOM removal

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bbd1482594832bb90d3e81a425ebd7