### PR TITLE
feat: add theme loader

### DIFF
--- a/themes/theme.json
+++ b/themes/theme.json
@@ -1,0 +1,12 @@
+{
+  "fonts": {
+    "chapter": {"family": "Segoe UI", "size": 11, "weight": "bold"},
+    "title": {"family": "Segoe UI", "size": 12, "weight": "bold"}
+  },
+  "colors": {
+    "path": "#666666"
+  },
+  "icons": {
+    "app": "appicon.png"
+  }
+}


### PR DESCRIPTION
## Summary
- load themes from /themes to configure fonts, colors, and icons
- apply loaded theme in UI build
- provide default theme with bundled app icon reference (no icon file included)
- remove appicon.png so the user can supply their own asset

## Testing
- `python -m py_compile branching_novel_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5398a1c832ba542eff352748c65