### PR TITLE
Support assignment conditions in choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Conditions and expressions support:
 - Comparisons: `== != < <= > >=`.
 - Logical operators: `!` (not), `&`/`&&` (and), `|`/`||` (or).
 - Parentheses for grouping.
+- Assignment expressions such as `x = 1` or `x += 2`. When a condition
+  contains only assignments the choice is still shown. If assignments and
+  other tests are combined with `and`, each part runs from left to right and
+  all non-assignment expressions must evaluate to true.
 
 Lines starting with `;` are treated as comments and ignored. Empty lines still
 serve only as paragraph separators.


### PR DESCRIPTION
## Summary
- allow buttons with assignment-only conditions to remain visible
- evaluate assignments and boolean tests sequentially when combined with `and`
- document assignment expressions in condition syntax

## Testing
- `python -m py_compile branching_novel_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc04b8ab84832baddb98d58e845ebc