### PR TITLE
Freeze previously rendered paragraphs while keeping dynamic title

### DIFF
--- a/branching_novel_app.py
+++ b/branching_novel_app.py
@@ -26,6 +26,7 @@ class Step:
     branch_id: str
     chosen_text: Optional[str] = None
     choice_actions: List[Action] = field(default_factory=list)
+    rendered_paragraphs: List[str] = field(default_factory=list)
 
 
 class BranchingNovelApp(tk.Tk):
@@ -160,6 +161,7 @@ class BranchingNovelApp(tk.Tk):
                 "branch_id": step.branch_id,
                 "chosen_text": step.chosen_text,
                 "choice_actions": [a.__dict__ for a in step.choice_actions],
+                "rendered_paragraphs": step.rendered_paragraphs,
             })
         data = {
             "history": hist_data,
@@ -217,6 +219,7 @@ class BranchingNovelApp(tk.Tk):
                 branch_id=h.get("branch_id", ""),
                 chosen_text=h.get("chosen_text"),
                 choice_actions=[Action(**a) for a in h.get("choice_actions", [])],
+                rendered_paragraphs=h.get("rendered_paragraphs", []),
             )
             for h in hist
         ]
@@ -495,7 +498,14 @@ class BranchingNovelApp(tk.Tk):
             if not br:
                 continue
             if br.paragraphs:
-                lines.append("\n\n".join(self._interpolate(p) for p in br.paragraphs))
+                if not step.rendered_paragraphs:
+                    state_i = self._compute_state(i)
+                    prev_state = self.state
+                    self.state = state_i
+                    step.rendered_paragraphs = [self._interpolate(p) for p in br.paragraphs]
+                    self.state = prev_state
+                    self.history[i] = step
+                lines.append("\n\n".join(step.rendered_paragraphs))
             if i + 1 < end and step.chosen_text:
                 lines.append(f"> {step.chosen_text}")
         text = "\n".join(lines)


### PR DESCRIPTION
## Summary
- Cache interpolated paragraphs per step so earlier text isn't updated when variables change
- Persist cached paragraphs in save/load routines
- Title continues to reflect real-time variable state

## Testing
- `python -m py_compile branching_novel_app.py branching_novel.py story_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c323edc832bb8da1657a68b1f32