### PR TITLE
Add locale loading from bundled directories with sample translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 themes/
-locales/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -98,3 +98,11 @@ You wake up with __coins__ coins.
 ```
 python branching_novel.py path/to/story.bnov
 ```
+
+## Localization
+
+Interface strings are loaded from JSON files located in a `locales` directory
+next to the executable. To add a new language, drop a file named
+`<lang>.json` in this folder containing translated key/value pairs. For
+example, placing `locales/fr.json` alongside the program enables French
+translations.

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,14 @@
+{
+    "warning": "Advertencia",
+    "error": "Error",
+    "start_over": "Comenzar de nuevo",
+    "reset_warning": "Todo el progreso se perderá.\n¿Reiniciar desde el principio?",
+    "exit": "Salir",
+    "ok": "Aceptar",
+    "cancel": "Cancelar",
+    "add": "Añadir",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "open": "Abrir",
+    "save": "Guardar"
+}

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,14 @@
+{
+    "warning": "警告",
+    "error": "エラー",
+    "start_over": "最初からやり直す",
+    "reset_warning": "進行状況はすべて失われます。\n最初から再開しますか？",
+    "exit": "終了",
+    "ok": "OK",
+    "cancel": "キャンセル",
+    "add": "追加",
+    "edit": "編集",
+    "delete": "削除",
+    "open": "開く",
+    "save": "保存"
+}


### PR DESCRIPTION
## Summary
- Load locale strings from a `locales` folder next to the executable before checking user app data
- Document how to add new language files
- Provide sample Spanish and Japanese locale JSON files

## Testing
- `python -m py_compile i18n.py`
- `python -m py_compile branching_novel.py`
- `python -m json.tool locales/es.json >/dev/null`
- `python -m json.tool locales/ja.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68bcf982d8d0832b9549649272d792ed