### PR TITLE
Fix inline comment stripping

### DIFF
--- a/story_parser.py
+++ b/story_parser.py
@@ -183,8 +183,7 @@ class StoryParser:
                 if in_brace:
                     in_brace -= 1
             elif ch == ';' and in_brace == 0:
-                if i > 0 and line[i - 1].isspace():
-                    return line[:i].rstrip()
+                return line[:i].rstrip()
         return line.rstrip()
 
     def _remove_comments(self, lines: List[str]) -> List[str]:


### PR DESCRIPTION
## Summary
- ensure inline comments are removed even when `;` follows text with no preceding whitespace

## Testing
- `pytest`
- `python -m py_compile story_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd020a28b0832badd57eb46596a953