### PR TITLE
Preserve comments in preview

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1781,7 +1781,12 @@ class ChapterEditor(tk.Tk):
             return
 
         self._apply_body_to_model()
-        txt = self.story.serialize()
+
+        parser = StoryParser()
+        serialized = self.story.serialize().rstrip()
+        current = self.txt_preview.get("1.0", tk.END).rstrip("\n")
+        clean_current = "\n".join(parser._remove_comments(current.splitlines())).rstrip()
+        txt = current if clean_current == serialized else serialized
 
         self._preview_updating = True
         try:


### PR DESCRIPTION
## Summary
- keep user-entered comments in `.bnov` preview when refreshing or saving

## Testing
- `python -m py_compile branching_novel_editor.py story_parser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd1cec96fc832bbb3254db3fcb7b9a