### PR TITLE
Fix undo/redo removing comments

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1280,7 +1280,9 @@ class ChapterEditor(tk.Tk):
 
         self.txt_body.config(state="normal")
         self.txt_body.delete("1.0", tk.END)
-        if br.paragraphs:
+        if br.raw_text:
+            self.txt_body.insert(tk.END, br.raw_text)
+        elif br.paragraphs:
             self.txt_body.insert(tk.END, "\n\n".join(br.paragraphs))
         highlight_variables(self.txt_body, lambda: self._collect_variables())
         self.txt_body.edit_modified(False)
@@ -1298,6 +1300,7 @@ class ChapterEditor(tk.Tk):
             return
         br = self.story.branches[self.current_branch_id]
         raw = self.txt_body.get("1.0", tk.END).rstrip("\n")
+        br.raw_text = raw
         lines = raw.splitlines()
         parser = StoryParser()
         # Remove comment lines and inline comments so they don't appear

--- a/story_parser.py
+++ b/story_parser.py
@@ -28,6 +28,7 @@ class Branch:
     paragraphs: List[str] = field(default_factory=list)
     choices: List[Choice] = field(default_factory=list)
     actions: List[Action] = field(default_factory=list)
+    raw_text: str = ""
     line: int = 0
     source: str = ""
 
@@ -105,9 +106,14 @@ class Story:
             for bid, br in ch.branches.items():
                 br_header = f"# {br.branch_id}: {br.title}" if br.title else f"# {br.branch_id}"
                 lines.append(br_header)
-                for p in br.paragraphs:
-                    lines.append(p.rstrip())
+                if br.raw_text:
+                    for ln in br.raw_text.rstrip().splitlines():
+                        lines.append(ln.rstrip())
                     lines.append("")
+                else:
+                    for p in br.paragraphs:
+                        lines.append(p.rstrip())
+                        lines.append("")
                 op_map = {
                     "add": "+=",
                     "sub": "-=",


### PR DESCRIPTION
## Summary
- preserve raw branch text in Branch dataclass
- restore raw branch comments when loading and serializing branches

## Testing
- `python -m py_compile branching_novel_editor.py story_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd1f0227ac832bb0b346128228df15