### PR TITLE
Fix comment duplication when switching tabs

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1790,7 +1790,12 @@ class ChapterEditor(tk.Tk):
                 for c in comments_before.get(idx, []):
                     if c not in existing:
                         merged.append(c)
-                merged.append(line + inline_comments.get(idx, ""))
+                        existing.add(c)
+                base = parser._strip_inline_comment(line)
+                if line[len(base):]:
+                    merged.append(line)
+                else:
+                    merged.append(line + inline_comments.get(idx, ""))
                 recent_comments = []
                 idx += 1
         if trailing:


### PR DESCRIPTION
## Summary
- avoid repeating inline comments when syncing branch editor with code editor

## Testing
- `python3 -m py_compile branching_novel_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd7bdd4db8832b80dde2e1a5f3cd82