### PR TITLE
Fix block comment duplication in code editor

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1790,7 +1790,10 @@ class ChapterEditor(tk.Tk):
                 for c in comments_before.get(idx, []):
                     if c not in existing:
                         merged.append(c)
-                        existing.add(c)
+                # ``existing`` is intentionally not updated here so that
+                # identical comment lines (e.g., block comment delimiters
+                # marked by lone ';') are preserved in their original order
+                # without being mistakenly deduplicated.
                 base = parser._strip_inline_comment(line)
                 if line[len(base):]:
                     merged.append(line)

--- a/tests/test_merge_comments.py
+++ b/tests/test_merge_comments.py
@@ -1,0 +1,20 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from branching_novel_editor import ChapterEditor
+
+
+def _merge(editor, original: str, updated: str) -> str:
+    return editor._merge_comments(original, updated)
+
+
+def test_block_comment_not_duplicated_after_multiple_merges():
+    editor = ChapterEditor.__new__(ChapterEditor)
+    original = ';\nblock\n;\nline1\n'
+    updated = 'line1\n'
+    first = _merge(editor, original, updated)
+    second = _merge(editor, first, updated)
+    assert first == second == ';\nblock\n;\nline1'
+


### PR DESCRIPTION
## Summary
- prevent block comment delimiters from being deduplicated when syncing tabs
- add regression test ensuring block comments remain stable across merges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be4f4bc4d4832b8a2add5621d63cee