### PR TITLE
Display code comments in branch editor

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1845,6 +1845,13 @@ class ChapterEditor(tk.Tk):
             if not silent:
                 messagebox.showerror(tr("parse_error"), str(e))
             return False
+        # 댓글이 포함된 원본에서 분기 제목과 본문을 다시 추출
+        branch_texts = parser.extract_branch_texts(txt)
+        for bid, br in story.branches.items():
+            if bid in branch_texts:
+                title, body = branch_texts[bid]
+                br.title = title
+                br.raw_text = body
         self.story = story
         self.current_branch_id = story.start_id
         br = self.story.get_branch(self.current_branch_id) if self.current_branch_id else None

--- a/tests/test_branch_comment_sync.py
+++ b/tests/test_branch_comment_sync.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from story_parser import StoryParser
+
+
+def test_branch_comments_sync_from_code():
+    text = (
+        "@chapter c1: Chapter\n"
+        "# b1: Title ;note\n"
+        "line1\n"
+        "; comment\n"
+        "line2\n"
+        "* choice -> b2\n"
+    )
+    parser = StoryParser()
+    story = parser.parse(text)
+    # Comments are stripped during parse
+    br = story.branches['b1']
+    assert br.title == 'Title'
+    assert br.raw_text == ''
+
+    branch_texts = parser.extract_branch_texts(text)
+    for bid, br in story.branches.items():
+        if bid in branch_texts:
+            br.title, br.raw_text = branch_texts[bid]
+
+    br = story.branches['b1']
+    assert br.title == 'Title ;note'
+    assert br.raw_text == 'line1\n; comment\nline2'


### PR DESCRIPTION
## Summary
- Capture branch titles and bodies with comments using `extract_branch_texts`
- Populate branch editor fields with comments from the code view
- Add tests ensuring comment lines are synced from the code editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be51f3ede4832bbfb4fe0c3a70db36