### PR TITLE
Handle block comments when merging

### DIFF
--- a/branching_novel_editor.py
+++ b/branching_novel_editor.py
@@ -1780,9 +1780,17 @@ class ChapterEditor(tk.Tk):
         merged: List[str] = []
         recent_comments: List[str] = []
         idx = 0  # index for non-comment lines
+        in_block = False
         for line in upd_lines:
             stripped = line.strip()
-            if stripped.startswith(';'):
+            if stripped == ';':
+                merged.append(line)
+                recent_comments.append(line)
+                in_block = not in_block
+            elif in_block:
+                merged.append(line)
+                recent_comments.append(line)
+            elif stripped.startswith(';'):
                 merged.append(line)
                 recent_comments.append(line)
             else:

--- a/tests/test_merge_comments.py
+++ b/tests/test_merge_comments.py
@@ -18,3 +18,10 @@ def test_block_comment_not_duplicated_after_multiple_merges():
     second = _merge(editor, first, updated)
     assert first == second == ';\nblock\n;\nline1'
 
+
+def test_block_comment_at_end_not_duplicated_when_merging_same():
+    editor = ChapterEditor.__new__(ChapterEditor)
+    original = 'line1\n;\nblock\n;\n'
+    merged = _merge(editor, original, original)
+    assert merged == original.rstrip()
+


### PR DESCRIPTION
## Summary
- avoid duplicating lines inside block comments when merging edits
- add regression test for trailing block comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be53df545c832bbcc75f9b4742c424